### PR TITLE
Bridge fees

### DIFF
--- a/offchain-modules/packages/app-rpc-server/src/handler.ts
+++ b/offchain-modules/packages/app-rpc-server/src/handler.ts
@@ -255,6 +255,19 @@ export class ForceBridgeAPIV1Handler implements API.ForceBridgeAPIV1 {
           },
         };
       }
+      case 'Cardano': {
+        // use Ada's asset interface to reference the core config which holds bridge fees
+        const asset = new AdaAsset(payload.xchainAssetIdent);
+        const bridgeFee = asset.getBridgeFee('in');
+        return {
+          fee: {
+            network: 'Nervos',
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            ident: getTokenShadowIdent('Cardano', payload.xchainAssetIdent)!,
+            amount: bridgeFee,
+          },
+        };
+      }
       default:
         throw new Error('invalid bridge chain type');
     }
@@ -273,6 +286,18 @@ export class ForceBridgeAPIV1Handler implements API.ForceBridgeAPIV1 {
         return {
           fee: {
             network: 'Ethereum',
+            ident: payload.xchainAssetIdent,
+            amount: bridgeFee,
+          },
+        };
+      }
+      case 'Cardano': {
+        // use Ada's asset interface to reference the core config which holds bridge fees
+        const asset = new AdaAsset(payload.xchainAssetIdent);
+        const bridgeFee = asset.getBridgeFee('out');
+        return {
+          fee: {
+            network: 'Cardano',
             ident: payload.xchainAssetIdent,
             amount: bridgeFee,
           },

--- a/offchain-modules/packages/scripts/src/cardano-integ.ts
+++ b/offchain-modules/packages/scripts/src/cardano-integ.ts
@@ -1,18 +1,15 @@
-import fs from 'fs';
 import path from 'path';
 import * as CardanoWasm from '@emurgo/cardano-serialization-lib-nodejs';
-import { ValInfos } from '@force-bridge/cli/src/changeVal';
 import { KeyStore } from '@force-bridge/keystore/dist';
 import { OwnerCellConfig } from '@force-bridge/x/dist/ckb/tx-helper/deploy';
-import { AdaConfig, Config, WhiteListEthAsset, CkbDeps } from '@force-bridge/x/dist/config';
+import { Config, CkbDeps } from '@force-bridge/x/dist/config';
 import { asyncSleep, privateKeyToCkbPubkeyHash, writeJsonToFile, genRandomHex } from '@force-bridge/x/dist/utils';
 import { logger, initLog } from '@force-bridge/x/dist/utils/logger';
 import * as utils from '@force-bridge/x/dist/xchain/ada/utils';
-import { AdaChain } from '@force-bridge/x/dist/xchain/ada/wallet-interface';
 import * as lodash from 'lodash';
 import * as shelljs from 'shelljs';
 import { handleDb, startVerifierService } from './integration';
-import { execShellCmd, pathFromProjectRoot } from './utils';
+import { pathFromProjectRoot } from './utils';
 import { cardanoBatchTest } from './utils/cardano_batch_test';
 import { deployDev, genRandomVerifierConfig, AdaVerifierConfig } from './utils/deploy-cardano';
 
@@ -200,6 +197,8 @@ async function main() {
       confirmNumber: 10,
       startBlockHeight: 1,
       networkId: utils.cardanoTestnetNetworkId(),
+      bridgeFeeIn: 20,
+      bridgeFeeOut: 30,
     },
     ckb: {
       ckbRpcUrl: 'http://127.0.0.1:8114',
@@ -232,7 +231,8 @@ async function main() {
   );
 
   const command = `FORCE_BRIDGE_KEYSTORE_PASSWORD=${FORCE_BRIDGE_KEYSTORE_PASSWORD} ${forcecli} collector -cfg ${configPath}/collector/force_bridge.json`;
-  const collectorProcess = shelljs.exec(command, { async: true });
+  // start collector process
+  shelljs.exec(command, { async: true });
   await asyncSleep(80000);
   const bridgeMultiSigAddr = getBridgeAddr(multisigConfig);
   await cardanoBatchTest(

--- a/offchain-modules/packages/x/src/ckb/model/asset.ts
+++ b/offchain-modules/packages/x/src/ckb/model/asset.ts
@@ -86,8 +86,10 @@ export abstract class Asset {
       case ChainType.EOS:
       case ChainType.TRON:
       case ChainType.POLKADOT:
-      case ChainType.CARDANO:
-        return '0';
+      case ChainType.CARDANO: {
+        if (direction === 'in') return ForceBridgeCore.config.ada.bridgeFeeIn;
+        return ForceBridgeCore.config.ada.bridgeFeeOut;
+      }
     }
   }
   public getHumanizedDescription(amount: string): string {

--- a/offchain-modules/packages/x/src/config.ts
+++ b/offchain-modules/packages/x/src/config.ts
@@ -111,6 +111,8 @@ export interface AdaConfig {
   startBlockHeight: number;
   networkId: number;
   privateKey?: string;
+  bridgeFeeOut: string;
+  bridgeFeeIn: string;
 }
 
 export interface logConfig {


### PR DESCRIPTION
Motivation for changes is simple: there was no way to get Cardano bridge fees previously. Motivation for how is that an ideal solution mimics how fees are currently implemented for Eth + BSC 